### PR TITLE
fix: Bad substitution on build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,8 +121,8 @@ RUN set -eu ; \
         mv OraProtoBuf.pb.h ../src/common/OraProtoBuf.pb.h ; \
         cd .. ; \
     fi ; \
-    mkdir cmake-build-${BUILD_TYPE,,}-x86_64 ; \
-    cd cmake-build-${BUILD_TYPE,,}-x86_64 ; \
+    mkdir cmake-build-${BUILD_TYPE}-x86_64 ; \
+    cd cmake-build-${BUILD_TYPE}-x86_64 ; \
     cmake ${BUILDARGS} ; \
     cmake --build ./ --target OpenLogReplicator -j ; \
     mkdir /opt/OpenLogReplicator ; \


### PR DESCRIPTION
fixed Bad substitution on build docker image
![image](https://user-images.githubusercontent.com/1937723/179926038-56f462b8-4a7b-4c83-9e6f-f4b0225c69bc.png)
